### PR TITLE
Add Tailwind-based welcome page with theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/*.map
+dist/*.d.ts

--- a/dist/script.js
+++ b/dist/script.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const themeToggle = document.getElementById('theme-toggle');
+const html = document.documentElement;
+const userPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const storedTheme = localStorage.getItem('theme');
+if (storedTheme === 'dark' || (!storedTheme && userPrefersDark)) {
+    html.classList.add('dark');
+}
+themeToggle?.addEventListener('click', () => {
+    if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+    }
+    else {
+        html.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+    }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Korradi.dev</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: {
+              blue: '#1e3a8a',
+              orange: '#f97316'
+            }
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="h-full bg-white text-black dark:bg-black dark:text-gray-200">
+  <main class="min-h-screen flex flex-col items-center justify-center text-center space-y-6 p-4">
+    <h1 class="text-4xl md:text-6xl font-extrabold bg-gradient-to-r from-brand-blue via-brand-orange to-black bg-clip-text text-transparent">
+      Welcome to Korradi.dev
+    </h1>
+    <p class="text-lg md:text-xl max-w-xl">
+      Exploring the future with code.
+    </p>
+    <button id="theme-toggle" class="px-6 py-2 rounded-md bg-brand-blue text-white hover:bg-brand-orange focus:outline-none focus:ring-2 focus:ring-brand-orange">
+      Toggle Theme
+    </button>
+  </main>
+  <script type="module" src="./dist/script.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "gpt",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gpt",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gpt",
+  "version": "1.0.0",
+  "description": "Connected to codex chatgpt",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,0 +1,18 @@
+const themeToggle = document.getElementById('theme-toggle') as HTMLButtonElement | null;
+const html = document.documentElement;
+const userPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const storedTheme = localStorage.getItem('theme');
+
+if (storedTheme === 'dark' || (!storedTheme && userPrefersDark)) {
+  html.classList.add('dark');
+}
+
+themeToggle?.addEventListener('click', () => {
+  if (html.classList.contains('dark')) {
+    html.classList.remove('dark');
+    localStorage.setItem('theme', 'light');
+  } else {
+    html.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,47 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    "rootDir": "src",
+    "outDir": "dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": false,
+    "declaration": false,
+    "declarationMap": false,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+  }
+}


### PR DESCRIPTION
## Summary
- Add index.html using Tailwind CSS and custom brand colors
- Implement TypeScript theme toggle with dark and light modes
- Configure TypeScript build and project metadata

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68976027d09083228eb879f7c592c520