### PR TITLE
Add snake game and tile

### DIFF
--- a/dist/snake.js
+++ b/dist/snake.js
@@ -1,0 +1,66 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const tileSize = 20;
+const tiles = canvas.width / tileSize;
+let snake = [{ x: tiles / 2, y: tiles / 2 }];
+let direction = { x: 0, y: 0 };
+let food = randomFood();
+function randomFood() {
+    return {
+        x: Math.floor(Math.random() * tiles),
+        y: Math.floor(Math.random() * tiles)
+    };
+}
+document.addEventListener('keydown', (e) => {
+    switch (e.key) {
+        case 'ArrowUp':
+            if (direction.y === 1)
+                break;
+            direction = { x: 0, y: -1 };
+            break;
+        case 'ArrowDown':
+            if (direction.y === -1)
+                break;
+            direction = { x: 0, y: 1 };
+            break;
+        case 'ArrowLeft':
+            if (direction.x === 1)
+                break;
+            direction = { x: -1, y: 0 };
+            break;
+        case 'ArrowRight':
+            if (direction.x === -1)
+                break;
+            direction = { x: 1, y: 0 };
+            break;
+    }
+});
+function gameLoop() {
+    const head = { x: snake[0].x + direction.x, y: snake[0].y + direction.y };
+    if (head.x < 0 ||
+        head.y < 0 ||
+        head.x >= tiles ||
+        head.y >= tiles ||
+        snake.some((s) => s.x === head.x && s.y === head.y)) {
+        alert('Game Over');
+        snake = [{ x: tiles / 2, y: tiles / 2 }];
+        direction = { x: 0, y: 0 };
+        food = randomFood();
+    }
+    snake.unshift(head);
+    if (head.x === food.x && head.y === food.y) {
+        food = randomFood();
+    }
+    else {
+        snake.pop();
+    }
+    ctx.fillStyle = 'black';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = 'lime';
+    snake.forEach((s) => ctx.fillRect(s.x * tileSize, s.y * tileSize, tileSize, tileSize));
+    ctx.fillStyle = 'red';
+    ctx.fillRect(food.x * tileSize, food.y * tileSize, tileSize, tileSize);
+}
+setInterval(gameLoop, 100);

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
     <button id="theme-toggle" class="px-6 py-2 rounded-md bg-brand-blue text-white hover:bg-brand-orange focus:outline-none focus:ring-2 focus:ring-brand-orange">
       Toggle Theme
     </button>
+    <a href="snake.html" class="w-32 h-32 flex items-center justify-center rounded-lg bg-brand-blue text-white hover:bg-brand-orange">
+      Play Snake
+    </a>
   </main>
   <script type="module" src="./dist/script.js"></script>
 </body>

--- a/snake.html
+++ b/snake.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Snake Game</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="h-full bg-black flex items-center justify-center">
+  <canvas id="game" width="400" height="400" class="border border-gray-500"></canvas>
+  <script type="module" src="./dist/snake.js"></script>
+</body>
+</html>

--- a/src/snake.ts
+++ b/src/snake.ts
@@ -1,0 +1,77 @@
+const canvas = document.getElementById('game') as HTMLCanvasElement;
+const ctx = canvas.getContext('2d')!;
+const tileSize = 20;
+const tiles = canvas.width / tileSize;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+let snake: Point[] = [{ x: tiles / 2, y: tiles / 2 }];
+let direction: Point = { x: 0, y: 0 };
+let food: Point = randomFood();
+
+function randomFood(): Point {
+  return {
+    x: Math.floor(Math.random() * tiles),
+    y: Math.floor(Math.random() * tiles)
+  };
+}
+
+document.addEventListener('keydown', (e) => {
+  switch (e.key) {
+    case 'ArrowUp':
+      if (direction.y === 1) break;
+      direction = { x: 0, y: -1 };
+      break;
+    case 'ArrowDown':
+      if (direction.y === -1) break;
+      direction = { x: 0, y: 1 };
+      break;
+    case 'ArrowLeft':
+      if (direction.x === 1) break;
+      direction = { x: -1, y: 0 };
+      break;
+    case 'ArrowRight':
+      if (direction.x === -1) break;
+      direction = { x: 1, y: 0 };
+      break;
+  }
+});
+
+function gameLoop() {
+  const head = { x: snake[0]!.x + direction.x, y: snake[0]!.y + direction.y };
+
+  if (
+    head.x < 0 ||
+    head.y < 0 ||
+    head.x >= tiles ||
+    head.y >= tiles ||
+    snake.some((s) => s.x === head.x && s.y === head.y)
+  ) {
+    alert('Game Over');
+    snake = [{ x: tiles / 2, y: tiles / 2 }];
+    direction = { x: 0, y: 0 };
+    food = randomFood();
+  }
+
+  snake.unshift(head);
+
+  if (head.x === food.x && head.y === food.y) {
+    food = randomFood();
+  } else {
+    snake.pop();
+  }
+
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = 'lime';
+  snake.forEach((s) => ctx.fillRect(s.x * tileSize, s.y * tileSize, tileSize, tileSize));
+
+  ctx.fillStyle = 'red';
+  ctx.fillRect(food.x * tileSize, food.y * tileSize, tileSize, tileSize);
+}
+
+setInterval(gameLoop, 100);


### PR DESCRIPTION
## Summary
- add navigation tile on homepage linking to a new snake game
- implement browser-based snake game

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68977e410b808322bee895d2bae4e39b